### PR TITLE
feat: Remove region parameter for 3.0 aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ module "s3_bucket" {
 | logging | Map containing access bucket logging configuration. | `map(string)` | `{}` | no |
 | object\_lock\_configuration | Map containing S3 object locking configuration. | `any` | `{}` | no |
 | policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | `string` | `null` | no |
-| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | `string` | `null` | no |
 | replication\_configuration | Map containing cross-region replication configuration. | `any` | `{}` | no |
 | request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | `string` | `null` | no |
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `false` | no |

--- a/examples/s3-replication/main.tf
+++ b/examples/s3-replication/main.tf
@@ -36,7 +36,6 @@ module "replica_bucket" {
   }
 
   bucket = local.destination_bucket_name
-  region = local.replica_region
   acl    = "private"
 
   versioning = {
@@ -48,7 +47,6 @@ module "s3_bucket" {
   source = "../../"
 
   bucket = local.bucket_name
-  region = local.origin_region
   acl    = "private"
 
   versioning = {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ resource "aws_s3_bucket" "this" {
   tags                = var.tags
   force_destroy       = var.force_destroy
   acceleration_status = var.acceleration_status
-  region              = var.region
   request_payer       = var.request_payer
 
   dynamic "website" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,12 +64,6 @@ variable "acceleration_status" {
   default     = null
 }
 
-variable "region" {
-  description = "(Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee."
-  type        = string
-  default     = null
-}
-
 variable "request_payer" {
   description = "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.35"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
The 3.0 aws provider does not allow a region parameter to the
aws_s3_bucket resource.